### PR TITLE
Tensorboard uint8 input

### DIFF
--- a/tensorboard.py
+++ b/tensorboard.py
@@ -73,7 +73,7 @@ class TBLogger(object):
                 img -= img.min()
                 img /= img.max()
                 img *= 255
-                img = img.astype('int8')
+                img = img.astype('uint8')
 
             # Write the image to a string
             s = StringIO()


### PR DESCRIPTION
Input for Tensorboard image summarios should be unsigned int8. Then the images look nice.